### PR TITLE
Use optimized build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or by downloading and extracting the zip.
 Then, install Rust from the [offical rust
 guide](https://www.rust-lang.org/tools/install).
 
-Compile the program using `rustc main.rs -o main`. Then you can run
+Compile the program using `rustc -O main.rs -o main`. Then you can run
 the program using `main`. By default, it will start with 1 digit, then
 2, then 3, etc, until you cancel the program. You can modify the
 starting value by change `n` in the source and recompiling.


### PR DESCRIPTION
If we're doing this in Rust because we need speed, then why not use all the speed we can get?

This changes the instructions to use an optimized build, rather than a debug build. It compiles slower, but will run faster, and I think that's what we want for intensive things like this.

This makes calculating digits 1-8 take about ~1.5 seconds on my computer, and with 9 it takes about 10 seconds.

In any case, super cool project!